### PR TITLE
Fix attachment title guessing behavior for http pages that are not text/html

### DIFF
--- a/todo/input.py
+++ b/todo/input.py
@@ -209,17 +209,19 @@ class CardTool:
     @staticmethod
     def title_to_link(card):
         # assumes card.name is the link you want
-        links = [n for n in card.name.split() if 'http' in n]
+        sp = card.name.split()
+        links = [n for n in sp if 'http' in n]
         existing_attachments = [a.name for a in card.get_attachments()]
         for l in links:
             if l not in existing_attachments:
                 card.attach(url=l)
-        # attempt to get the title of the link
+        # attempt to get the title of the link for a HTML page
         possible_title = get_title_of_webpage(links[0])
         if possible_title:
             CardTool.rename(card, default=possible_title)
         else:
-            CardTool.rename(card)
+            reconstructed = ' '.join([n for n in sp if not 'http' in n])
+            CardTool.rename(card, default=reconstructed)
 
     @staticmethod
     def manipulate_attachments(card):

--- a/todo/misc.py
+++ b/todo/misc.py
@@ -1,4 +1,5 @@
 import os
+import re
 import requests
 from todo import __version__, __author__
 try:
@@ -8,7 +9,7 @@ except OSError:
     choice = lambda n: n.pop()
 
 
-VALID_URL_REGEX = 'https?://.*\.'
+VALID_URL_REGEX = re.compile('https?://.*\.')
 
 
 class Colors:

--- a/todo/misc.py
+++ b/todo/misc.py
@@ -32,6 +32,8 @@ def get_title_of_webpage(url):
     headers = {'User-Agent': 'gtd.py version ' + __version__}
     try:
         resp = requests.get(url, headers=headers)
+        if 'text/html' not in resp.headers.get('Content-Type', ''):
+            return None
         as_text = resp.text
         return as_text[as_text.find('<title>') + 7:as_text.find('</title>')]
     except requests.exceptions.ConnectionError:


### PR DESCRIPTION
This PR checks the Content-Type header in the response body from a page when guessing the title of the page for card renaming purposes. This prevents binary data from being read by the program and interpreted as a title. It also changes the default for the card title in the case of a non-HTML page to the rest of the card title with the link stripped out.