### PR TITLE
Added new flags for `show cards` and added `show comments` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ share/*
 build/*
 dist/*
 *egg-info*
+.env

--- a/todo/__init__.py
+++ b/todo/__init__.py
@@ -1,3 +1,3 @@
 '''gtd.py'''
-__version__ = '0.6.12'
+__version__ = '0.7.12'
 __author__  = 'delucks'


### PR DESCRIPTION
This PR adds the following features

1. For `show cards`
The "assigned" flag, `--assigned|-a`,  when enabled only shows cards that are assigned to current user for the current board.

The "completed" flag, `--completed|-c`, when enabled only shows cards that are assigned to current user and are in the "done" list for the current board.

The "include_closed" flag, `--include_closed`, when enabled shows cards that are both non-archived (open) and archived (closed). This changes the default behaviour of cards to only show non-archived cards when the "include_closed" flag is not specified

2. For `show unresponded`
This command shows all unresponded comments that mention the current user's username. This is not restricted to the current board and will fetch comments from all boards that the user is part of.