### PR TITLE
Updated version of PyYAML and configuration file via env var

### DIFF
--- a/gtd.py
+++ b/gtd.py
@@ -227,8 +227,9 @@ def tsv_option(f):
 @click.pass_context
 def cli(top_level_context, board, color, banner):
     '''gtd.py'''
+    filename= os.getenv('GTDPYRC')
     try:
-        config = Configuration.from_file()
+        config = Configuration.from_file(filename)
     except GTDException:
         click.echo('Could not find a valid config file for gtd.')
         if click.confirm('Would you like to create it interactively?'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==5.4
+PyYAML==6.0
 py-trello==0.15.0
 click==7.0
 prompt_toolkit==3.0.3


### PR DESCRIPTION
After updating PyYAML dependency to version 6.0 i can correctly install gtd.py on archlinux.

I'm using different trello account between home and work.
To enable me to use gtd with multiple trello account i added the possibility to override configuration file via environment variable called GTDPYRC